### PR TITLE
rename virtualenv_dir variable to avoid collision with one in webhop-drupal-settings

### DIFF
--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -7,7 +7,7 @@
     group: "{{ scripts_group }}"
     mode: 0755
   register:
-    virtualenv_dir
+    awslogs_virtualenv_dir_output
 
 - block:
   - name: Install virtualenv package if virtualenv dir was created
@@ -28,4 +28,4 @@
       requirements: "{{ awslogs_scripts_dir }}/awslogs-requirements.txt"
       virtualenv: "{{ awslogs_virtualenv_dir }}"
 
-  when: virtualenv_dir | changed
+  when: awslogs_virtualenv_dir_output | changed


### PR DESCRIPTION
rename virtualenv_dir variable to avoid collision with one in webhop-drupal-settings