### PR TITLE
Add systemd support

### DIFF
--- a/files/awslogs.service
+++ b/files/awslogs.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=The CloudWatch Logs agent
+After=rc-local.service
+
+[Service]
+Type=simple
+Restart=always
+KillMode=process
+TimeoutSec=infinity
+PIDFile=/var/awslogs/state/awslogs.pid
+ExecStart=/var/awslogs/bin/awslogs-agent-launcher.sh --start --background --pidfile $PIDFILE --user awslogs --chuid awslogs &
+
+[Install]
+WantedBy=multi-user.target

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,12 +40,11 @@
     src: awslogs.service
     dest: /etc/systemd/system/awslogs.service
   when: ansible_lsb.major_release|int >= 16
-  
+
 - name: Install the cloudwatch agent config template
   copy:
     src: awslogs-agent.conf.j2
     dest: "{{ awslogs_scripts_dir }}/awslogs-agent.conf.j2"
-  when: ansible_lsb.major_release|int >= 16
 
 - name: "Ensure {{ awslogs_agent_config_dir }} exists for clients to put their config"
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,10 +35,17 @@
 - name: Install the AWS CloudWatch Logs daemon
   shell: python /tmp/awslogs-agent-setup.py --non-interactive --region=eu-central-1 --configfile=/tmp/emptyfile
 
+- name: Install a systemd startup file for the agent 
+  copy:
+    src: awslogs.service
+    dest: /etc/systemd/system/awslogs.service
+  when: ansible_lsb.major_release|int >= 16
+  
 - name: Install the cloudwatch agent config template
   copy:
     src: awslogs-agent.conf.j2
     dest: "{{ awslogs_scripts_dir }}/awslogs-agent.conf.j2"
+  when: ansible_lsb.major_release|int >= 16
 
 - name: "Ensure {{ awslogs_agent_config_dir }} exists for clients to put their config"
   file:
@@ -61,3 +68,21 @@
     mode: 0644
     owner: root
     group: root
+  when: ansible_lsb.major_release|int <= 14
+ 
+- name: Put systemd unit file in place if running on Ubuntu 16.04
+  template:
+    src: configure-cloudwatch-logs-systemd.service.j2
+    dest: /etc/systemd/system/configure-cloudwatch-logs.service
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_lsb.major_release|int >= 16
+
+- name: Enable the service in systemd
+  command: /bin/systemctl enable configure-cloudwatch-logs
+  when: ansible_lsb.major_release|int >= 16
+
+- name: Enable the awslogs.service service in systemd
+  command: /bin/systemctl enable awslogs.service 
+  when: ansible_lsb.major_release|int >= 16

--- a/templates/configure-cloudwatch-logs-systemd.service.j2
+++ b/templates/configure-cloudwatch-logs-systemd.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Configure Cloudwatch logs
+Documentation=https://github.com/zeebox/ansible-webhop-component-settings/blob/master/README.md
+Requires=network-online.target
+Before=awslogs.service
+
+[Service]
+Type=oneshot
+ExecStart={{ awslogs_virtualenv_dir }}/bin/python {{ awslogs_scripts_dir }}/configure_cloudwatch_logs.py {{ awslogs_agent_config_dir }} {{ awslogs_scripts_dir }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The AWS logs agent doesn't include support for systemd/Ubuntu 16.04.

Add it, and include a startup file for our configuration script that runs out of systemd too.