### PR TITLE
Default role name, rather than infering

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 awslogs_virtualenv_dir: /opt/beamly/virtualenvs/awslogs
 awslogs_scripts_dir: /opt/beamly/scripts/awslogs
 awslogs_agent_config_dir: /opt/beamly/config/awslogs-agent-config
+awslogs_role_name: awslogs
 scripts_owner: root
 scripts_group: root

--- a/tasks/component-setup.yml
+++ b/tasks/component-setup.yml
@@ -1,8 +1,3 @@
-- name: "Override the role name in the template search path"
-  set_fact:
-    awslogs_role_name: awslogs
-  when: awslogs_role_name is not defined
-
 - name: "Template the agent config template"
   template:
     # because this is being called by the including playbook we need to reference the template from its root


### PR DESCRIPTION
Minor operational step; remove infer of rolename when not explicitly setting and, instead, default it