### PR TITLE
Add support for CloudWatch subscription filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ log_config:
             metricNamespace: WEBHOP
             metricValue: '1'
             default_value: 0
+    subscription_filter:
+      name: "filter-name"
+      pattern: ""
+      destination_arn: "arn:aws:lambda:<region>:<account-id>:function:<function-name>"
 
   apache_access:
     log_file: "/var/log/apache2/access.log"

--- a/files/configure_cloudwatch_logs.py
+++ b/files/configure_cloudwatch_logs.py
@@ -132,6 +132,18 @@ def configure_logging(args):
             conn.put_metric_filter(log_group_name=log_group_name, filter_name=filter_name,
                                    filter_pattern=filter_pattern, metric_transformations=metric_transformations)
 
+        subscription_filter = cfg[log_group].get('subscription_filter')
+        if subscription_filter:
+            filter_name = subscription_filter['name']
+            LOG.info("Applying subscription filter {0} to {1}".format(filter_name, log_group_name))
+            conn.put_subscription_filter(
+                logGroupName=log_group_name,
+                filterName=filter_name,
+                filterPattern=subscription_filter['pattern'],
+                destinationArn=subscription_filter['destination_arn'],
+                distribution='ByLogStream'
+            )
+
 if __name__ == "__main__":
     FORMAT = "%(asctime)-15s : %(levelname)-8s : %(message)s"
     logging.basicConfig(format=FORMAT, level=logging.INFO)

--- a/files/configure_cloudwatch_logs.py
+++ b/files/configure_cloudwatch_logs.py
@@ -16,13 +16,17 @@ import requests
 
 LOG = logging.getLogger(__name__)
 
+EC2_METADATA_SERVICE_ENDPOINT = "http://169.254.169.254/latest"
+
 
 def get_instance_identity():
-    return requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document').json()
+    return requests.get('{0}/dynamic/instance-identity/document'.format(
+        EC2_METADATA_SERVICE_ENDPOINT)).json()
 
 
 def get_instance_reservation_id():
-    return requests.get('http://169.254.169.254/latest/meta-data/reservation-id').text
+    return requests.get('{0}/meta-data/reservation-id'.format(
+        EC2_METADATA_SERVICE_ENDPOINT)).text
 
 
 def get_instance_config():

--- a/files/configure_cloudwatch_logs.py
+++ b/files/configure_cloudwatch_logs.py
@@ -147,6 +147,7 @@ def configure_logging(args):
             )
         except conn.exceptions.ResourceNotFoundException:
             LOG.info("Creating log group {0}".format(log_group_name))
+            conn.create_log_group(log_group_name)
             conn.put_retention_policy(
                 logGroupName=log_group_name,
                 retentionInDays=retention_days

--- a/files/configure_cloudwatch_logs.py
+++ b/files/configure_cloudwatch_logs.py
@@ -147,7 +147,9 @@ def configure_logging(args):
             )
         except conn.exceptions.ResourceNotFoundException:
             LOG.info("Creating log group {0}".format(log_group_name))
-            conn.create_log_group(log_group_name)
+            conn.create_log_group(
+                logGroupName=log_group_name
+            )
             conn.put_retention_policy(
                 logGroupName=log_group_name,
                 retentionInDays=retention_days

--- a/files/configure_cloudwatch_logs.py
+++ b/files/configure_cloudwatch_logs.py
@@ -31,7 +31,7 @@ def get_instance_config():
         # IndexError because boto throws this when it tries to parse empty response
         raise SystemExit("Could not connect to instance metadata endpoint, bailing...")
 
-    config["account_id"] = metadata["document"]["accountId"]
+    config["account_id"] = identity_data["document"]["accountId"]
     config["inst_id"] = identity_data["document"]["instanceId"]
     config["region"] = identity_data["document"]["region"]
     config["reservation_id"] = metadata["reservation-id"]

--- a/files/configure_cloudwatch_logs.py
+++ b/files/configure_cloudwatch_logs.py
@@ -151,7 +151,6 @@ def configure_logging(args):
                 logGroupName=log_group_name,
                 retentionInDays=retention_days
             )
-            conn.put_retention_policy(log_group_name, retention_days)
 
         for metric_filter in cfg[log_group].get('metric_filters', []):
             filter_name = "{0}-{1}-{2}".format(template_vars["env"], template_vars["brand"], metric_filter['name'])

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,4 +1,5 @@
-boto
+boto3
 jinja2
 python-dateutil
 pyyaml
+requests


### PR DESCRIPTION
Adds support for subscription filters e.g. Lambda function, Elasticsearch Service, etc.

Note that both the filter_name and destination_arn values are treated as jinja2 templates as this enables us to target environment specific resources.

I've upgraded to boto3 in the process so that the `put_subscription_filter` API could be used.